### PR TITLE
Fix table structure mismatch.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -26,7 +26,7 @@ At this time, PHP's [named arguments](https://www.php.net/manual/en/functions.ar
 For LTS releases, such as Laravel 9, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 18 months and security fixes are provided for 2 years. For all additional libraries, including Lumen, only the latest release receives bug fixes. In addition, please review the database versions [supported by Laravel](/docs/{{version}}/database#introduction).
 
 | Version | PHP (*) | Release | Bug Fixes Until | Security Fixes Until |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | 6 (LTS) | 7.2 - 8.0 | September 3rd, 2019 | January 25th, 2022 | September 6th, 2022 |
 | 7 | 7.2 - 8.0 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
 | 8 | 7.3 - 8.1 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |


### PR DESCRIPTION
Structural inconsistencies will make bad results by tools that convert markdown to HTML or other formats.
 Therefore, it must be fixed.